### PR TITLE
Restrict owner role to read‑only

### DIFF
--- a/app/Http/Controllers/Admin/MiceCategoryController.php
+++ b/app/Http/Controllers/Admin/MiceCategoryController.php
@@ -22,6 +22,9 @@ class MiceCategoryController extends Controller
      */
     public function create()
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         return view('admin.mice_categories.create');
     }
 
@@ -30,6 +33,9 @@ class MiceCategoryController extends Controller
      */
     public function store(Request $request)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $validated = $request->validate([
             'name' => 'required|string|max:255|unique:mice_categories,name',
             'description' => 'nullable|string',
@@ -56,6 +62,9 @@ class MiceCategoryController extends Controller
      */
     public function edit(MiceCategory $miceCategory)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         return view('admin.mice_categories.edit', compact('miceCategory'));
     }
 
@@ -64,6 +73,9 @@ class MiceCategoryController extends Controller
      */
     public function update(Request $request, MiceCategory $miceCategory)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $validated = $request->validate([
             'name' => 'required|string|max:255|unique:mice_categories,name,' . $miceCategory->id,
             'description' => 'nullable|string',
@@ -80,6 +92,9 @@ class MiceCategoryController extends Controller
      */
     public function destroy(MiceCategory $miceCategory)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         try {
             $miceCategory->delete();
             return redirect()->route('admin.mice-categories.index')

--- a/app/Http/Controllers/Admin/PricePackageController.php
+++ b/app/Http/Controllers/Admin/PricePackageController.php
@@ -16,11 +16,17 @@ class PricePackageController extends Controller
 
     public function create()
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         return view('admin.price_packages.create');
     }
 
     public function store(Request $request)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $request->validate([
             'name' => 'required|string|max:255',
             'price' => 'required|numeric|min:0',
@@ -34,11 +40,17 @@ class PricePackageController extends Controller
 
     public function edit(PricePackage $pricePackage)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         return view('admin.price_packages.edit', compact('pricePackage'));
     }
 
     public function update(Request $request, PricePackage $pricePackage)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $request->validate([
             'name' => 'required|string|max:255',
             'price' => 'required|numeric|min:0',
@@ -56,6 +68,9 @@ class PricePackageController extends Controller
 
     public function destroy(PricePackage $pricePackage)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $pricePackage->delete();
         return redirect()->route('admin.price-packages.index')->with('success', 'Paket harga berhasil dihapus.');
     }

--- a/app/Http/Controllers/Admin/RevenueTargetController.php
+++ b/app/Http/Controllers/Admin/RevenueTargetController.php
@@ -47,6 +47,9 @@ class RevenueTargetController extends Controller
     // app\Http\Controllers\Admin\RevenueTargetController.php
     public function create()
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $properties = Property::orderBy('name')->get();
         ($properties); // PASTIKAN INI MASIH ADA UNTUK SEKARANG
 
@@ -61,6 +64,9 @@ class RevenueTargetController extends Controller
      */
     public function store(Request $request)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $request->validate([
             'property_id' => 'required|exists:properties,id',
             'month_year' => [
@@ -102,6 +108,9 @@ class RevenueTargetController extends Controller
      */
     public function edit(RevenueTarget $revenueTarget)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $properties = Property::orderBy('name')->get(); // Juga butuh ini untuk edit
         // Format month_year ke YYYY-MM untuk ditampilkan di input type="month"
         $revenueTarget->month_year_form = Carbon::parse($revenueTarget->month_year)->format('Y-m');
@@ -113,6 +122,9 @@ class RevenueTargetController extends Controller
      */
     public function update(Request $request, RevenueTarget $revenueTarget) // Route Model Binding
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
          $request->validate([
             'property_id' => 'required|exists:properties,id',
             'month_year' => [
@@ -145,6 +157,9 @@ class RevenueTargetController extends Controller
      */
     public function destroy(RevenueTarget $revenueTarget) // Route Model Binding
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $revenueTarget->delete();
         return redirect()->route('admin.revenue-targets.index')
             ->with('success', 'Target pendapatan berhasil dihapus.');

--- a/app/Http/Controllers/Admin/RoomController.php
+++ b/app/Http/Controllers/Admin/RoomController.php
@@ -23,6 +23,9 @@ class RoomController extends Controller
      */
     public function create(Property $property)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         return view('admin.rooms.create', compact('property'));
     }
 
@@ -31,6 +34,9 @@ class RoomController extends Controller
      */
     public function store(Request $request, Property $property)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'capacity' => 'nullable|string|max:255',
@@ -48,6 +54,9 @@ class RoomController extends Controller
      */
     public function edit(Room $room)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $property = $room->property;
         return view('admin.rooms.edit', compact('room', 'property'));
     }
@@ -57,6 +66,9 @@ class RoomController extends Controller
      */
     public function update(Request $request, Room $room)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'capacity' => 'nullable|string|max:255',
@@ -74,6 +86,9 @@ class RoomController extends Controller
      */
     public function destroy(Room $room)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $property = $room->property;
         $room->delete();
 

--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -19,6 +19,9 @@ class SettingController extends Controller
 
     public function store(Request $request)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         // Validasi input
         $validatedData = $request->validate([
             'app_name' => 'required|string|max:255',

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -25,6 +25,9 @@ class UserController extends Controller
      */
     public function create()
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $properties = Property::orderBy('name')->get();
         
         // Definisikan daftar peran yang bisa dipilih
@@ -44,6 +47,9 @@ class UserController extends Controller
      */
     public function store(Request $request)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
@@ -78,6 +84,9 @@ class UserController extends Controller
      */
     public function edit(User $user)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $properties = Property::orderBy('name')->get();
 
         // Definisikan daftar peran yang bisa dipilih
@@ -97,6 +106,9 @@ class UserController extends Controller
      */
     public function update(Request $request, User $user)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'.$user->id],
@@ -125,6 +137,9 @@ class UserController extends Controller
      */
     public function destroy(User $user)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         // Jangan hapus user dengan ID 1 (biasanya super admin)
         if ($user->id === 1) {
             return redirect()->route('admin.users.index')->with('error', 'Super Admin tidak dapat dihapus.');
@@ -138,6 +153,9 @@ class UserController extends Controller
      */
     public function trashedIndex()
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         $users = User::onlyTrashed()->with('property')->latest()->paginate(10);
         return view('admin.users.trashed', compact('users'));
     }
@@ -147,6 +165,9 @@ class UserController extends Controller
      */
     public function restore($id)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         User::onlyTrashed()->findOrFail($id)->restore();
         return redirect()->route('admin.users.trashed')->with('success', 'Pengguna berhasil dipulihkan.');
     }
@@ -156,6 +177,9 @@ class UserController extends Controller
      */
     public function forceDelete($id)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403, 'Akses ditolak. Hanya admin yang dapat melakukan aksi ini.');
+        }
         User::onlyTrashed()->findOrFail($id)->forceDelete();
         return redirect()->route('admin.users.trashed')->with('success', 'Pengguna berhasil dihapus permanen.');
     }

--- a/resources/views/admin/mice_categories/index.blade.php
+++ b/resources/views/admin/mice_categories/index.blade.php
@@ -4,9 +4,11 @@
             <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ __('Kategori MICE') }}
             </h2>
-            <a href="{{ route('admin.mice-categories.create') }}" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                Tambah Kategori
-            </a>
+            @if(auth()->user()->role == 'admin')
+                <a href="{{ route('admin.mice-categories.create') }}" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    Tambah Kategori
+                </a>
+            @endif
         </div>
     </x-slot>
 
@@ -31,12 +33,14 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ $category->name }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{{ $category->description ?? '-' }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                            <a href="{{ route('admin.mice-categories.edit', $category) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">Edit</a>
-                                            <form action="{{ route('admin.mice-categories.destroy', $category) }}" method="POST" class="inline-block ml-4" onsubmit="return confirm('Apakah Anda yakin ingin menghapus kategori ini?');">
-                                                @csrf
-                                                @method('DELETE')
-                                                <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Hapus</button>
-                                            </form>
+                                            @if(auth()->user()->role == 'admin')
+                                                <a href="{{ route('admin.mice-categories.edit', $category) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">Edit</a>
+                                                <form action="{{ route('admin.mice-categories.destroy', $category) }}" method="POST" class="inline-block ml-4" onsubmit="return confirm('Apakah Anda yakin ingin menghapus kategori ini?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Hapus</button>
+                                                </form>
+                                            @endif
                                         </td>
                                     </tr>
                                 @empty

--- a/resources/views/admin/price_packages/index.blade.php
+++ b/resources/views/admin/price_packages/index.blade.php
@@ -1,7 +1,9 @@
 <x-admin-layout>
     <div class="flex justify-between items-center mb-4">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">Manajemen Paket Harga</h2>
-        <a href="{{ route('admin.price-packages.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">+ Tambah Paket</a>
+        @if(auth()->user()->role == 'admin')
+            <a href="{{ route('admin.price-packages.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">+ Tambah Paket</a>
+        @endif
     </div>
     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
         <table class="min-w-full divide-y divide-gray-200">
@@ -20,11 +22,13 @@
                     <td class="px-6 py-4">Rp {{ number_format($package->price, 0, ',', '.') }}</td>
                     <td class="px-6 py-4">{{ $package->is_active ? 'Aktif' : 'Tidak Aktif' }}</td>
                     <td class="px-6 py-4">
-                        <a href="{{ route('admin.price-packages.edit', $package) }}" class="text-indigo-600">Edit</a>
-                        <form action="{{ route('admin.price-packages.destroy', $package) }}" method="POST" class="inline-block ml-2" onsubmit="return confirm('Hapus paket ini?');">
-                            @csrf @method('DELETE')
-                            <button type="submit" class="text-red-600">Hapus</button>
-                        </form>
+                        @if(auth()->user()->role == 'admin')
+                            <a href="{{ route('admin.price-packages.edit', $package) }}" class="text-indigo-600">Edit</a>
+                            <form action="{{ route('admin.price-packages.destroy', $package) }}" method="POST" class="inline-block ml-2" onsubmit="return confirm('Hapus paket ini?');">
+                                @csrf @method('DELETE')
+                                <button type="submit" class="text-red-600">Hapus</button>
+                            </form>
+                        @endif
                     </td>
                 </tr>
                 @endforeach

--- a/resources/views/admin/properties/show.blade.php
+++ b/resources/views/admin/properties/show.blade.php
@@ -8,10 +8,12 @@
                 <x-secondary-button onclick="window.history.back()">
                     {{ __('Kembali') }}
                 </x-secondary-button>
-                <a href="{{ route('admin.properties.edit', $property->id) }}"
-                   class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
-                    {{ __('Edit Properti') }}
-                </a>
+                @if(auth()->user()->role == 'admin')
+                    <a href="{{ route('admin.properties.edit', $property->id) }}"
+                       class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+                        {{ __('Edit Properti') }}
+                    </a>
+                @endif
             </div>
         </div>
     </x-slot>

--- a/resources/views/admin/revenue_targets/index.blade.php
+++ b/resources/views/admin/revenue_targets/index.blade.php
@@ -10,9 +10,11 @@
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900 dark:text-gray-100">
                     <div class="flex justify-end mb-4">
-                        <a href="{{ route('admin.revenue-targets.create') }}" class="inline-flex items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-500 active:bg-green-700 focus:outline-none focus:border-green-700 focus:ring ring-green-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            {{ __('Tambah Target Pendapatan') }}
-                        </a>
+                        @if(auth()->user()->role == 'admin')
+                            <a href="{{ route('admin.revenue-targets.create') }}" class="inline-flex items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-500 active:bg-green-700 focus:outline-none focus:border-green-700 focus:ring ring-green-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                {{ __('Tambah Target Pendapatan') }}
+                            </a>
+                        @endif
                     </div>
 
                     <form method="GET" action="{{ route('admin.revenue-targets.index') }}" class="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-md">
@@ -90,12 +92,14 @@
                                             Rp {{ number_format($target->target_amount, 0, ',', '.') }}
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                            <a href="{{ route('admin.revenue-targets.edit', $target->id) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200 mr-2">Edit</a>
-                                            <form action="{{ route('admin.revenue-targets.destroy', $target->id) }}" method="POST" class="inline-block" onsubmit="return confirm('Apakah Anda yakin ingin menghapus target ini?');">
-                                                @csrf
-                                                @method('DELETE')
-                                                <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Hapus</button>
-                                            </form>
+                                            @if(auth()->user()->role == 'admin')
+                                                <a href="{{ route('admin.revenue-targets.edit', $target->id) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200 mr-2">Edit</a>
+                                                <form action="{{ route('admin.revenue-targets.destroy', $target->id) }}" method="POST" class="inline-block" onsubmit="return confirm('Apakah Anda yakin ingin menghapus target ini?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Hapus</button>
+                                                </form>
+                                            @endif
                                         </td>
                                     </tr>
                                 @empty

--- a/resources/views/admin/rooms/index.blade.php
+++ b/resources/views/admin/rooms/index.blade.php
@@ -4,9 +4,11 @@
             <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ __('Kelola Ruangan untuk: ') . $property->name }}
             </h2>
-            <a href="{{ route('admin.properties.rooms.create', $property) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                Tambah Ruangan
-            </a>
+            @if(auth()->user()->role == 'admin')
+                <a href="{{ route('admin.properties.rooms.create', $property) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    Tambah Ruangan
+                </a>
+            @endif
         </div>
     </x-slot>
 
@@ -31,12 +33,14 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ $room->name }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{{ $room->capacity }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                            <a href="{{ route('admin.rooms.edit', $room) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">Edit</a>
-                                            <form action="{{ route('admin.rooms.destroy', $room) }}" method="POST" class="inline-block ml-4" onsubmit="return confirm('Apakah Anda yakin ingin menghapus ruangan ini?');">
-                                                @csrf
-                                                @method('DELETE')
-                                                <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Hapus</button>
-                                            </form>
+                                            @if(auth()->user()->role == 'admin')
+                                                <a href="{{ route('admin.rooms.edit', $room) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">Edit</a>
+                                                <form action="{{ route('admin.rooms.destroy', $room) }}" method="POST" class="inline-block ml-4" onsubmit="return confirm('Apakah Anda yakin ingin menghapus ruangan ini?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Hapus</button>
+                                                </form>
+                                            @endif
                                         </td>
                                     </tr>
                                 @empty

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -66,9 +66,11 @@
                                 </div>
                             </div>
 
-                            <div class="flex items-center gap-4 mt-6">
-                                <x-primary-button>{{ __('Simpan Pengaturan') }}</x-primary-button>
-                            </div>
+                            @if(auth()->user()->role == 'admin')
+                                <div class="flex items-center gap-4 mt-6">
+                                    <x-primary-button>{{ __('Simpan Pengaturan') }}</x-primary-button>
+                                </div>
+                            @endif
                         </div>
                     </form>
                 </div>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -19,11 +19,13 @@
                 <x-nav-link :href="route('admin.users.trashed')" :active="request()->routeIs('admin.users.trashed')">
                     {{ __('Pengguna Dinonaktifkan') }}
                 </x-nav-link>
-                {{-- Tombol untuk Tambah Pengguna Baru --}}
-                <a href="{{ route('admin.users.create') }}"
-                   class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 dark:hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
-                    {{ __('+ Tambah Pengguna') }}
-                </a>
+                @if(auth()->user()->role == 'admin')
+                    {{-- Tombol untuk Tambah Pengguna Baru --}}
+                    <a href="{{ route('admin.users.create') }}"
+                       class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 dark:hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+                        {{ __('+ Tambah Pengguna') }}
+                    </a>
+                @endif
             </nav>
         </div>
     </x-slot>
@@ -80,17 +82,19 @@
                                             {{ $user->created_at ? $user->created_at->isoFormat('D MMM YYYY, HH:mm') : '-' }}
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
-                                            <a href="{{ route('admin.users.edit', $user->id) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">Edit</a>
-                                            
-                                            {{-- !! FORM HAPUS (SOFT DELETE) !! --}}
-                                            @if(Auth::id() !== $user->id) {{-- Admin tidak bisa menghapus diri sendiri --}}
-                                                <form method="POST" action="{{ route('admin.users.destroy', $user->id) }}" class="inline-block" onsubmit="return confirm('Apakah Anda yakin ingin menonaktifkan pengguna {{ addslashes($user->name) }}? Pengguna ini tidak akan bisa login lagi tetapi datanya tetap ada.');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Nonaktifkan</button>
-                                                </form>
+                                            @if(auth()->user()->role == 'admin')
+                                                <a href="{{ route('admin.users.edit', $user->id) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">Edit</a>
+
+                                                {{-- !! FORM HAPUS (SOFT DELETE) !! --}}
+                                                @if(Auth::id() !== $user->id)
+                                                    <form method="POST" action="{{ route('admin.users.destroy', $user->id) }}" class="inline-block" onsubmit="return confirm('Apakah Anda yakin ingin menonaktifkan pengguna {{ addslashes($user->name) }}? Pengguna ini tidak akan bisa login lagi tetapi datanya tetap ada.');">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">Nonaktifkan</button>
+                                                    </form>
+                                                @endif
+                                                {{-- !! AKHIR FORM HAPUS !! --}}
                                             @endif
-                                            {{-- !! AKHIR FORM HAPUS !! --}}
                                         </td>
                                     </tr>
                                 @empty


### PR DESCRIPTION
## Summary
- restrict modification actions in admin controllers to admin users only
- hide create/edit/delete UI elements for owner role
- conditionally show edit property button
- disable saving settings for owner

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863609c0f0c832ab0202f4f99d0a061