### PR TITLE
Enable admin control of property incomes

### DIFF
--- a/app/Http/Controllers/Admin/PropertyController.php
+++ b/app/Http/Controllers/Admin/PropertyController.php
@@ -106,6 +106,7 @@ class PropertyController extends Controller
 
             $dayData = new \stdClass();
             $dayData->date = $date->toDateTimeString();
+            $dayData->id = $income->id ?? null;
 
             foreach ($dbDailyIncomeColumns as $column) {
                 $dayData->{$column} = $income->{$column} ?? 0;

--- a/resources/views/admin/properties/show.blade.php
+++ b/resources/views/admin/properties/show.blade.php
@@ -100,9 +100,12 @@
 
             {{-- Tabel Riwayat Pendapatan --}}
             <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg p-6">
-                <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
-                    Riwayat Pendapatan Harian
-                </h3>
+                <div class="flex justify-between items-center mb-4">
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Riwayat Pendapatan Harian</h3>
+                    @if(auth()->user()->role === 'admin')
+                        <a href="{{ route('admin.properties.incomes.create', $property->id) }}" class="px-4 py-2 bg-blue-600 text-white rounded-md text-sm">Tambah Pendapatan</a>
+                    @endif
+                </div>
                 @if($incomes->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Tidak ada data pendapatan untuk periode yang dipilih.</p>
                 @else
@@ -115,6 +118,9 @@
                                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ $label }}</th>
                                     @endforeach
                                     <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider font-bold">Total</th>
+                                    @if(auth()->user()->role === 'admin')
+                                        <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Aksi</th>
+                                    @endif
                                 </tr>
                             </thead>
                             <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
@@ -148,6 +154,16 @@
                                             </td>
                                         @endforeach
                                         <td class="px-4 py-4 whitespace-nowrap text-sm font-semibold text-gray-900 dark:text-gray-100 text-right">{{ number_format($rowTotal, 0, ',', '.') }}</td>
+                                        @if(auth()->user()->role === 'admin')
+                                            <td class="px-4 py-4 whitespace-nowrap text-sm space-x-2">
+                                                <a href="{{ route('admin.properties.incomes.edit', $income->id) }}" class="text-indigo-600 hover:text-indigo-900">Edit</a>
+                                                <form action="{{ route('admin.properties.incomes.destroy', $income->id) }}" method="POST" class="inline-block" onsubmit="return confirm('Hapus data ini?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-900">Hapus</button>
+                                                </form>
+                                            </td>
+                                        @endif
                                     </tr>
                                 @endforeach
                             </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,12 +90,19 @@ Route::middleware(['auth', 'verified'])->group(function () {
             
             Route::resource('users', AdminUserController::class)->except(['show']);
             Route::get('users/trashed', [AdminUserController::class, 'trashedIndex'])->name('users.trashed');
-            Route::put('users/{id}/restore', [AdminUserController::class, 'restore'])->name('users.restore');  
+            Route::put('users/{id}/restore', [AdminUserController::class, 'restore'])->name('users.restore');
             Route::delete('users/{id}/force-delete', [AdminUserController::class, 'forceDelete'])->name('users.forceDelete');
-            
+
             // [FIX] Pindahkan route spesifik SEBELUM route resource
             Route::get('/properties/compare', [AdminPropertyController::class, 'showComparisonForm'])->name('properties.compare_page');
             Route::get('/properties/compare/results', [AdminPropertyController::class, 'showComparisonResults'])->name('properties.compare.results');
+
+            // Kelola pendapatan harian untuk setiap properti
+            Route::get('properties/{property}/incomes/create', [PropertyIncomeController::class, 'create'])->name('properties.incomes.create');
+            Route::post('properties/{property}/incomes', [PropertyIncomeController::class, 'store'])->name('properties.incomes.store');
+            Route::get('properties/incomes/{dailyIncome}/edit', [PropertyIncomeController::class, 'edit'])->name('properties.incomes.edit');
+            Route::put('properties/incomes/{dailyIncome}', [PropertyIncomeController::class, 'update'])->name('properties.incomes.update');
+            Route::delete('properties/incomes/{dailyIncome}', [PropertyIncomeController::class, 'destroy'])->name('properties.incomes.destroy');
             Route::resource('properties', AdminPropertyController::class);
             
             Route::resource('revenue-targets', RevenueTargetController::class);


### PR DESCRIPTION
## Summary
- allow admin to manage daily incomes for all properties
- expose admin routes for creating, editing and deleting incomes
- support property parameter in income controller
- show action links on admin property income table

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686364b14284832aba4b1fef49fbb880