### PR TITLE
Add MICE room fields for property users

### DIFF
--- a/app/Exports/PropertyIncomesExport.php
+++ b/app/Exports/PropertyIncomesExport.php
@@ -34,6 +34,8 @@ class PropertyIncomesExport implements FromQuery, WithHeadings, WithMapping, Sho
             ->where('property_id', $this->propertyId)
             ->select( // Pilih kolom yang benar-benar dibutuhkan
                 'date',
+                'mice_rooms',
+                'mice_room_income',
                 'mice_income',
                 'fnb_income',
                 'offline_room_income',
@@ -59,6 +61,8 @@ class PropertyIncomesExport implements FromQuery, WithHeadings, WithMapping, Sho
     {
         return [
             'Tanggal',
+            'MICE (Kamar)',
+            'Pendapatan MICE Kamar (Rp)',
             'Pendapatan MICE (Rp)',
             'Pendapatan F&B (Rp)',
             'Pendapatan Kamar Offline (Rp)',
@@ -75,6 +79,7 @@ class PropertyIncomesExport implements FromQuery, WithHeadings, WithMapping, Sho
     public function map($income): array
     {
         $totalDailyIncome = $income->mice_income +
+                            $income->mice_room_income +
                             $income->fnb_income +
                             $income->offline_room_income +
                             $income->online_room_income +
@@ -82,6 +87,8 @@ class PropertyIncomesExport implements FromQuery, WithHeadings, WithMapping, Sho
 
         return [
             Carbon::parse($income->date)->isoFormat('D MMMM YYYY'),
+            $income->mice_rooms,
+            $income->mice_room_income,
             $income->mice_income,
             $income->fnb_income,
             $income->offline_room_income,

--- a/app/Http/Controllers/Admin/IncomeController.php
+++ b/app/Http/Controllers/Admin/IncomeController.php
@@ -38,9 +38,11 @@ class IncomeController extends Controller
             'corp_rooms' => 'nullable|integer|min:0',
             'compliment_rooms' => 'nullable|integer|min:0',
             'house_use_rooms' => 'nullable|integer|min:0',
+            'mice_rooms' => 'nullable|integer|min:0',
             // Validasi Pendapatan
             'offline_room_income' => 'nullable|numeric|min:0',
             'online_room_income' => 'nullable|numeric|min:0',
+            'mice_room_income' => 'nullable|numeric|min:0',
             'ta_income' => 'nullable|numeric|min:0',
             'gov_income' => 'nullable|numeric|min:0',
             'corp_income' => 'nullable|numeric|min:0',
@@ -89,9 +91,11 @@ class IncomeController extends Controller
             'corp_rooms' => 'nullable|integer|min:0',
             'compliment_rooms' => 'nullable|integer|min:0',
             'house_use_rooms' => 'nullable|integer|min:0',
+            'mice_rooms' => 'nullable|integer|min:0',
             // Validasi Pendapatan
             'offline_room_income' => 'nullable|numeric|min:0',
             'online_room_income' => 'nullable|numeric|min:0',
+            'mice_room_income' => 'nullable|numeric|min:0',
             'ta_income' => 'nullable|numeric|min:0',
             'gov_income' => 'nullable|numeric|min:0',
             'corp_income' => 'nullable|numeric|min:0',

--- a/app/Http/Controllers/PropertyIncomeController.php
+++ b/app/Http/Controllers/PropertyIncomeController.php
@@ -104,6 +104,8 @@ class PropertyIncomeController extends Controller
             'offline_room_income' => 'required|numeric|min:0',
             'online_rooms' => 'required|integer|min:0',
             'online_room_income' => 'required|numeric|min:0',
+            'mice_rooms' => 'required|integer|min:0',
+            'mice_room_income' => 'required|numeric|min:0',
             'ta_rooms' => 'required|integer|min:0',
             'ta_income' => 'required|numeric|min:0',
             'gov_rooms' => 'required|integer|min:0',
@@ -127,12 +129,12 @@ class PropertyIncomeController extends Controller
         $total_rooms_sold =
             $validatedData['offline_rooms'] + $validatedData['online_rooms'] + $validatedData['ta_rooms'] +
             $validatedData['gov_rooms'] + $validatedData['corp_rooms'] + $validatedData['compliment_rooms'] +
-            $validatedData['house_use_rooms'];
+            $validatedData['house_use_rooms'] + $validatedData['mice_rooms'];
 
         $total_rooms_revenue =
             $validatedData['offline_room_income'] + $validatedData['online_room_income'] + $validatedData['ta_income'] +
             $validatedData['gov_income'] + $validatedData['corp_income'] + $validatedData['compliment_income'] +
-            $validatedData['house_use_income'] + $validatedData['mice_income'];
+            $validatedData['house_use_income'] + $validatedData['mice_room_income'] + $validatedData['mice_income'];
 
         $total_fb_revenue = $validatedData['breakfast_income'] + $validatedData['lunch_income'] + $validatedData['dinner_income'];
         $total_revenue = $total_rooms_revenue + $total_fb_revenue + $validatedData['others_income'];
@@ -188,6 +190,8 @@ class PropertyIncomeController extends Controller
             'offline_room_income' => 'required|numeric|min:0',
             'online_rooms' => 'required|integer|min:0',
             'online_room_income' => 'required|numeric|min:0',
+            'mice_rooms' => 'required|integer|min:0',
+            'mice_room_income' => 'required|numeric|min:0',
             'ta_rooms' => 'required|integer|min:0',
             'ta_income' => 'required|numeric|min:0',
             'gov_rooms' => 'required|integer|min:0',
@@ -212,12 +216,12 @@ class PropertyIncomeController extends Controller
         $total_rooms_sold =
             $validatedData['offline_rooms'] + $validatedData['online_rooms'] + $validatedData['ta_rooms'] +
             $validatedData['gov_rooms'] + $validatedData['corp_rooms'] + $validatedData['compliment_rooms'] +
-            $validatedData['house_use_rooms'];
+            $validatedData['house_use_rooms'] + $validatedData['mice_rooms'];
 
         $total_rooms_revenue =
             $validatedData['offline_room_income'] + $validatedData['online_room_income'] + $validatedData['ta_income'] +
             $validatedData['gov_income'] + $validatedData['corp_income'] + $validatedData['compliment_income'] +
-            $validatedData['house_use_income'] + $validatedData['mice_income'];
+            $validatedData['house_use_income'] + $validatedData['mice_room_income'] + $validatedData['mice_income'];
 
         $total_fb_revenue = $validatedData['breakfast_income'] + $validatedData['lunch_income'] + $validatedData['dinner_income'];
         $total_revenue = $total_rooms_revenue + $total_fb_revenue + $validatedData['others_income'];

--- a/app/Models/DailyIncome.php
+++ b/app/Models/DailyIncome.php
@@ -23,6 +23,7 @@ class DailyIncome extends Model
         // Kolom jumlah kamar
         'offline_rooms',
         'online_rooms',
+        'mice_rooms',
         'ta_rooms',
         'gov_rooms',
         'corp_rooms',
@@ -32,6 +33,7 @@ class DailyIncome extends Model
         // Kolom pendapatan
         'offline_room_income',
         'online_room_income',
+        'mice_room_income',
         'ta_income',
         'gov_income',
         'corp_income',

--- a/database/migrations/2025_07_19_030637_add_mice_room_fields_to_daily_incomes_table.php
+++ b/database/migrations/2025_07_19_030637_add_mice_room_fields_to_daily_incomes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('daily_incomes', function (Blueprint $table) {
+            // Tambahkan kolom untuk jumlah kamar MICE dan pendapatannya
+            $table->integer('mice_rooms')->default(0)->after('online_room_income');
+            $table->decimal('mice_room_income', 15, 2)->default(0)->after('mice_rooms');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('daily_incomes', function (Blueprint $table) {
+            $table->dropColumn(['mice_rooms', 'mice_room_income']);
+        });
+    }
+};

--- a/resources/views/admin/incomes/create.blade.php
+++ b/resources/views/admin/incomes/create.blade.php
@@ -84,6 +84,16 @@
                                 <x-input-label for="house_use_income" :value="__('House Use (Pendapatan)')" />
                                 <x-text-input id="house_use_income" class="block mt-1 w-full" type="number" name="house_use_income" :value="old('house_use_income', 0)" />
                             </div>
+
+                            <!-- MICE Room -->
+                            <div>
+                                <x-input-label for="mice_rooms" :value="__('MICE (Kamar)')" />
+                                <x-text-input id="mice_rooms" class="block mt-1 w-full" type="number" name="mice_rooms" :value="old('mice_rooms', 0)" />
+                            </div>
+                            <div>
+                                <x-input-label for="mice_room_income" :value="__('MICE (Pendapatan Kamar)')" />
+                                <x-text-input id="mice_room_income" class="block mt-1 w-full" type="number" name="mice_room_income" :value="old('mice_room_income', 0)" />
+                            </div>
                             
                             <div class="col-span-full border-t pt-4"></div>
                             

--- a/resources/views/admin/incomes/edit.blade.php
+++ b/resources/views/admin/incomes/edit.blade.php
@@ -85,6 +85,16 @@
                                 <x-input-label for="house_use_income" :value="__('House Use (Pendapatan)')" />
                                 <x-text-input id="house_use_income" class="block mt-1 w-full" type="number" name="house_use_income" :value="old('house_use_income', $income->house_use_income)" />
                             </div>
+
+                            <!-- MICE Room -->
+                            <div>
+                                <x-input-label for="mice_rooms" :value="__('MICE (Kamar)')" />
+                                <x-text-input id="mice_rooms" class="block mt-1 w-full" type="number" name="mice_rooms" :value="old('mice_rooms', $income->mice_rooms)" />
+                            </div>
+                            <div>
+                                <x-input-label for="mice_room_income" :value="__('MICE (Pendapatan Kamar)')" />
+                                <x-text-input id="mice_room_income" class="block mt-1 w-full" type="number" name="mice_room_income" :value="old('mice_room_income', $income->mice_room_income)" />
+                            </div>
                             
                             <div class="col-span-full border-t pt-4"></div>
                             

--- a/resources/views/property/dashboard.blade.php
+++ b/resources/views/property/dashboard.blade.php
@@ -26,12 +26,14 @@
                         <div class="mt-4 p-4 bg-green-100 dark:bg-green-700 rounded-lg">
                             <h4 class="font-semibold">Pendapatan Hari Ini ({{ \Carbon\Carbon::today()->isoFormat('LL') }})</h4>
                             <p>MICE: Rp {{ number_format($todayIncome->mice_income ?? 0, 0, ',', '.') }}</p>
+                            <p>MICE Rooms: {{ $todayIncome->mice_rooms ?? 0 }} kamar / Rp {{ number_format($todayIncome->mice_room_income ?? 0, 0, ',', '.') }}</p>
                             <p>F&B: Rp {{ number_format($todayIncome->fnb_income ?? 0, 0, ',', '.') }}</p>
                             <p>Kamar Offline: Rp {{ number_format($todayIncome->offline_room_income ?? 0, 0, ',', '.') }}</p>
                             <p>Kamar Online: Rp {{ number_format($todayIncome->online_room_income ?? 0, 0, ',', '.') }}</p>
                             <p>Lainnya: Rp {{ number_format($todayIncome->others_income ?? 0, 0, ',', '.') }}</p>
                             <p class="font-bold mt-1">Total: Rp {{ number_format(
                                 ($todayIncome->mice_income ?? 0) +
+                                ($todayIncome->mice_room_income ?? 0) +
                                 ($todayIncome->fnb_income ?? 0) +
                                 ($todayIncome->offline_room_income ?? 0) +
                                 ($todayIncome->online_room_income ?? 0) +

--- a/resources/views/property/income/create.blade.php
+++ b/resources/views/property/income/create.blade.php
@@ -93,6 +93,16 @@
                                 <x-input-label for="house_use_income" :value="__('House Use (Pendapatan)')" />
                                 <x-text-input id="house_use_income" class="block mt-1 w-full" type="number" name="house_use_income" :value="old('house_use_income', 0)" />
                             </div>
+
+                            <!-- MICE Room -->
+                            <div>
+                                <x-input-label for="mice_rooms" :value="__('MICE (Kamar)')" />
+                                <x-text-input id="mice_rooms" class="block mt-1 w-full" type="number" name="mice_rooms" :value="old('mice_rooms', 0)" />
+                            </div>
+                            <div>
+                                <x-input-label for="mice_room_income" :value="__('MICE (Pendapatan Kamar)')" />
+                                <x-text-input id="mice_room_income" class="block mt-1 w-full" type="number" name="mice_room_income" :value="old('mice_room_income', 0)" />
+                            </div>
                             
                             <!-- Other Incomes (no rooms) -->
                             <div class="col-span-full border-t pt-4"></div>

--- a/resources/views/property/income/edit.blade.php
+++ b/resources/views/property/income/edit.blade.php
@@ -95,6 +95,16 @@
                                 <x-input-label for="house_use_income" :value="__('House Use (Pendapatan)')" />
                                 <x-text-input id="house_use_income" class="block mt-1 w-full" type="number" name="house_use_income" :value="old('house_use_income', $dailyIncome->house_use_income)" />
                             </div>
+
+                            <!-- MICE Room -->
+                            <div>
+                                <x-input-label for="mice_rooms" :value="__('MICE (Kamar)')" />
+                                <x-text-input id="mice_rooms" class="block mt-1 w-full" type="number" name="mice_rooms" :value="old('mice_rooms', $dailyIncome->mice_rooms)" />
+                            </div>
+                            <div>
+                                <x-input-label for="mice_room_income" :value="__('MICE (Pendapatan Kamar)')" />
+                                <x-text-input id="mice_room_income" class="block mt-1 w-full" type="number" name="mice_room_income" :value="old('mice_room_income', $dailyIncome->mice_room_income)" />
+                            </div>
                             
                             <!-- Other Incomes (no rooms) -->
                             <div class="col-span-full border-t pt-4"></div>

--- a/resources/views/property/income/index.blade.php
+++ b/resources/views/property/income/index.blade.php
@@ -56,6 +56,7 @@
                                         <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Corp (Kamar/Rp)</th>
                                         <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Compliment (Kamar/Rp)</th>
                                         <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">House Use (Kamar/Rp)</th>
+                                        <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">MICE Room (Kamar/Rp)</th>
                                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">MICE</th>
                                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">F&B</th>
                                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Lainnya</th>
@@ -76,6 +77,7 @@
                                                        ($income->corp_income ?? 0) +
                                                        ($income->compliment_income ?? 0) +
                                                        ($income->house_use_income ?? 0) +
+                                                       ($income->mice_room_income ?? 0) +
                                                        ($income->mice_income ?? 0) +
                                                        ($income->fb_income ?? 0) + // Ini akan menjumlahkan Breakfast, Lunch, Dinner
                                                        ($income->others_income ?? 0);
@@ -91,6 +93,8 @@
                                         <td class="px-4 py-4 whitespace-nowrap text-sm text-center">{{ $income->corp_rooms ?? 0 }} / <span class="text-gray-500 dark:text-gray-300">{{ number_format($income->corp_income ?? 0, 0, ',', '.') }}</span></td>
                                         <td class="px-4 py-4 whitespace-nowrap text-sm text-center">{{ $income->compliment_rooms ?? 0 }} / <span class="text-gray-500 dark:text-gray-300">{{ number_format($income->compliment_income ?? 0, 0, ',', '.') }}</span></td>
                                         <td class="px-4 py-4 whitespace-nowrap text-sm text-center">{{ $income->house_use_rooms ?? 0 }} / <span class="text-gray-500 dark:text-gray-300">{{ number_format($income->house_use_income ?? 0, 0, ',', '.') }}</span></td>
+
+                                        <td class="px-4 py-4 whitespace-nowrap text-sm text-center">{{ $income->mice_rooms ?? 0 }} / <span class="text-gray-500 dark:text-gray-300">{{ number_format($income->mice_room_income ?? 0, 0, ',', '.') }}</span></td>
 
                                         <td class="px-4 py-4 whitespace-nowrap text-sm text-right text-gray-500 dark:text-gray-300">{{ number_format($income->mice_income ?? 0, 0, ',', '.') }}</td>
                                         


### PR DESCRIPTION
## Summary
- add migration for `mice_rooms` and `mice_room_income`
- allow admin/property controllers to handle new fields
- include new fields in DailyIncome model
- update property dashboards and income forms with MICE room inputs
- extend export and table views for the new data

## Testing
- `php -l database/migrations/2025_07_19_030637_add_mice_room_fields_to_daily_incomes_table.php`
- `find app -name '*.php' -print0 | xargs -0 -n1 php -l`
- `./vendor/bin/phpunit --stop-on-failure` *(fails: duplicate column breakfast_income)*

------
https://chatgpt.com/codex/tasks/task_b_687b0b33b8bc83238f6623688fc800dd