### PR TITLE
feat: add ecommerce reservation calendar

### DIFF
--- a/app/Http/Controllers/Ecommerce/DashboardController.php
+++ b/app/Http/Controllers/Ecommerce/DashboardController.php
@@ -8,6 +8,7 @@ use App\Services\ReservationPriceService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\DailyOccupancy;
+use App\Models\Reservation;
 
 class DashboardController extends Controller
 {
@@ -32,8 +33,15 @@ class DashboardController extends Controller
         $occupancyToday = DailyOccupancy::where('property_id', $property->id)
                                         ->where('date', today()->toDateString())
                                         ->first();
-        
+
         $currentOccupancy = $occupancyToday ? $occupancyToday->occupied_rooms : 0;
+
+        $ownReservationRooms = Reservation::where('property_id', $property->id)
+            ->where('user_id', $user->id)
+            ->whereDate('checkin_date', today()->toDateString())
+            ->sum('number_of_rooms');
+
+        $currentOccupancy += $ownReservationRooms;
         $currentPrices = $this->priceService->getCurrentPricesForProperty($property->id, today()->toDateString());
 
         // Log the activity

--- a/app/Http/Controllers/Ecommerce/ReservationController.php
+++ b/app/Http/Controllers/Ecommerce/ReservationController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Ecommerce;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
+use Carbon\Carbon;
+
+class ReservationController extends Controller
+{
+    public function events(Request $request)
+    {
+        $user = Auth::user();
+        $reservations = Reservation::where('property_id', $user->property_id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        $events = $reservations->map(function ($reservation) {
+            return [
+                'title' => $reservation->guest_name,
+                'start' => $reservation->checkin_date,
+                'end' => Carbon::parse($reservation->checkout_date)->addDay()->toDateString(),
+            ];
+        });
+
+        return response()->json($events);
+    }
+}

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -19,10 +19,16 @@ class Reservation extends Model
         'checkin_date',
         'checkout_date',
         'number_of_rooms',
+        'user_id',
     ];
 
     public function property(): BelongsTo
     {
         return $this->belongsTo(Property::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/database/migrations/2025_08_04_080452_add_user_id_to_reservations_table.php
+++ b/database/migrations/2025_08_04_080452_add_user_id_to_reservations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/resources/views/ecommerce/dashboard.blade.php
+++ b/resources/views/ecommerce/dashboard.blade.php
@@ -1,4 +1,9 @@
 <x-app-layout>
+    @push('styles')
+    <style>
+        #calendar { min-height: 60vh; }
+    </style>
+    @endpush
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ __('Dashboard Harga OTA') }}
@@ -72,6 +77,28 @@
                     </div>
                 </div>
             </div>
+
+            <div class="mt-8">
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 dark:text-gray-100">
+                        <h4 class="text-xl font-semibold mb-4">Reservasi Saya</h4>
+                        <div id="calendar"></div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
+    @push('scripts')
+    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var calendarEl = document.getElementById('calendar');
+            var calendar = new FullCalendar.Calendar(calendarEl, {
+                initialView: 'dayGridMonth',
+                events: '{{ route('ecommerce.reservations.events') }}'
+            });
+            calendar.render();
+        });
+    </script>
+    @endpush
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -157,6 +157,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('ecommerce.')
         ->group(function () {
             Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
+            Route::get('reservations/events', [\App\Http\Controllers\Ecommerce\ReservationController::class, 'events'])->name('reservations.events');
         });
 });
 


### PR DESCRIPTION
## Summary
- track reservation creators and calendar events
- auto-update occupancy from stored reservations
- show reservations calendar on ecommerce dashboard

## Testing
- `php artisan test` *(fails: General error: 1 table "properties" already exists)*

------
https://chatgpt.com/codex/tasks/task_b_6890690f629c83298774c3773ee7926a