### PR TITLE
feat: manage ecommerce reservations

### DIFF
--- a/app/Http/Controllers/Ecommerce/DashboardController.php
+++ b/app/Http/Controllers/Ecommerce/DashboardController.php
@@ -8,6 +8,7 @@ use App\Services\ReservationPriceService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\DailyOccupancy;
+use App\Models\Reservation;
 
 class DashboardController extends Controller
 {
@@ -32,13 +33,25 @@ class DashboardController extends Controller
         $occupancyToday = DailyOccupancy::where('property_id', $property->id)
                                         ->where('date', today()->toDateString())
                                         ->first();
-        
+
         $currentOccupancy = $occupancyToday ? $occupancyToday->occupied_rooms : 0;
+
+        $ownReservationRooms = Reservation::where('property_id', $property->id)
+            ->where('user_id', $user->id)
+            ->whereDate('checkin_date', today()->toDateString())
+            ->sum('number_of_rooms');
+
+        $currentOccupancy += $ownReservationRooms;
         $currentPrices = $this->priceService->getCurrentPricesForProperty($property->id, today()->toDateString());
+
+        $reservations = Reservation::where('property_id', $property->id)
+            ->where('user_id', $user->id)
+            ->orderBy('checkin_date')
+            ->get();
 
         // Log the activity
         $this->logActivity('Melihat dashboard harga OTA.', $request);
 
-        return view('ecommerce.dashboard', compact('property', 'currentPrices', 'currentOccupancy'));
+        return view('ecommerce.dashboard', compact('property', 'currentPrices', 'currentOccupancy', 'reservations'));
     }
 }

--- a/app/Http/Controllers/Ecommerce/ReservationController.php
+++ b/app/Http/Controllers/Ecommerce/ReservationController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers\Ecommerce;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+use App\Models\DailyOccupancy;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
+use Carbon\Carbon;
+
+class ReservationController extends Controller
+{
+    public function create()
+    {
+        return view('ecommerce.reservations.create');
+    }
+
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+
+        $validated = $request->validate([
+            'guest_name' => 'required|string|max:255',
+            'guest_email' => 'nullable|email',
+            'checkin_date' => 'required|date',
+            'checkout_date' => 'required|date|after_or_equal:checkin_date',
+            'number_of_rooms' => 'required|integer|min:1',
+        ]);
+
+        $reservation = Reservation::create($validated + [
+            'property_id' => $user->property_id,
+            'user_id' => $user->id,
+            'source' => 'Manual',
+            'final_price' => 0,
+        ]);
+
+        $occupancy = DailyOccupancy::firstOrCreate(
+            [
+                'property_id' => $user->property_id,
+                'date' => $reservation->checkin_date,
+            ],
+            ['occupied_rooms' => 0]
+        );
+        $occupancy->increment('occupied_rooms', $reservation->number_of_rooms);
+
+        return redirect()->route('ecommerce.dashboard')->with('success', 'Reservasi berhasil dibuat.');
+    }
+
+    public function edit(Reservation $reservation)
+    {
+        $this->authorizeReservation($reservation);
+        return view('ecommerce.reservations.edit', compact('reservation'));
+    }
+
+    public function update(Request $request, Reservation $reservation)
+    {
+        $this->authorizeReservation($reservation);
+
+        $validated = $request->validate([
+            'guest_name' => 'required|string|max:255',
+            'guest_email' => 'nullable|email',
+            'checkin_date' => 'required|date',
+            'checkout_date' => 'required|date|after_or_equal:checkin_date',
+            'number_of_rooms' => 'required|integer|min:1',
+        ]);
+
+        $oldDate = $reservation->checkin_date;
+        $oldRooms = $reservation->number_of_rooms;
+
+        $reservation->update($validated);
+
+        if ($oldDate !== $reservation->checkin_date || $oldRooms !== $reservation->number_of_rooms) {
+            $oldOccupancy = DailyOccupancy::where('property_id', $reservation->property_id)
+                ->where('date', $oldDate)
+                ->first();
+            if ($oldOccupancy) {
+                $oldOccupancy->decrement('occupied_rooms', $oldRooms);
+            }
+
+            $newOccupancy = DailyOccupancy::firstOrCreate(
+                [
+                    'property_id' => $reservation->property_id,
+                    'date' => $reservation->checkin_date,
+                ],
+                ['occupied_rooms' => 0]
+            );
+            $newOccupancy->increment('occupied_rooms', $reservation->number_of_rooms);
+        }
+
+        return redirect()->route('ecommerce.dashboard')->with('success', 'Reservasi berhasil diperbarui.');
+    }
+
+    public function destroy(Reservation $reservation)
+    {
+        $this->authorizeReservation($reservation);
+
+        $occupancy = DailyOccupancy::where('property_id', $reservation->property_id)
+            ->where('date', $reservation->checkin_date)
+            ->first();
+        if ($occupancy) {
+            $occupancy->decrement('occupied_rooms', $reservation->number_of_rooms);
+        }
+
+        $reservation->delete();
+
+        return redirect()->route('ecommerce.dashboard')->with('success', 'Reservasi berhasil dihapus.');
+    }
+
+    public function events(Request $request)
+    {
+        $user = Auth::user();
+        $reservations = Reservation::where('property_id', $user->property_id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        $events = $reservations->map(function ($reservation) {
+            return [
+                'id' => $reservation->id,
+                'title' => $reservation->guest_name,
+                'start' => $reservation->checkin_date,
+                'end' => Carbon::parse($reservation->checkout_date)->addDay()->toDateString(),
+            ];
+        });
+
+        return response()->json($events);
+    }
+
+    private function authorizeReservation(Reservation $reservation): void
+    {
+        $user = Auth::user();
+        if ($reservation->user_id !== $user->id) {
+            abort(403);
+        }
+    }
+}

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -19,10 +19,16 @@ class Reservation extends Model
         'checkin_date',
         'checkout_date',
         'number_of_rooms',
+        'user_id',
     ];
 
     public function property(): BelongsTo
     {
         return $this->belongsTo(Property::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/database/migrations/2025_08_04_080452_add_user_id_to_reservations_table.php
+++ b/database/migrations/2025_08_04_080452_add_user_id_to_reservations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/resources/views/ecommerce/dashboard.blade.php
+++ b/resources/views/ecommerce/dashboard.blade.php
@@ -1,4 +1,9 @@
 <x-app-layout>
+    @push('styles')
+    <style>
+        #calendar { min-height: 60vh; }
+    </style>
+    @endpush
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ __('Dashboard Harga OTA') }}
@@ -72,6 +77,72 @@
                     </div>
                 </div>
             </div>
+
+            <div class="mt-8">
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 dark:text-gray-100">
+                        <h4 class="text-xl font-semibold mb-4">Reservasi Saya</h4>
+
+                        @if(session('success'))
+                            <div class="mb-4 p-2 bg-green-100 text-green-700 rounded">{{ session('success') }}</div>
+                        @endif
+
+                        <a href="{{ route('ecommerce.reservations.create') }}" class="inline-block mb-4 px-4 py-2 bg-indigo-600 text-white rounded">Tambah Reservasi</a>
+
+                        @if($reservations->isNotEmpty())
+                            <div class="overflow-x-auto mb-6">
+                                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                    <thead class="bg-gray-50 dark:bg-gray-700">
+                                        <tr>
+                                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Tamu</th>
+                                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Tanggal</th>
+                                            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Kamar</th>
+                                            <th class="px-4 py-2"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                                        @foreach($reservations as $reservation)
+                                            <tr>
+                                                <td class="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">{{ $reservation->guest_name }}</td>
+                                                <td class="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">{{ $reservation->checkin_date }} - {{ $reservation->checkout_date }}</td>
+                                                <td class="px-4 py-2 text-sm text-right text-gray-900 dark:text-gray-100">{{ $reservation->number_of_rooms }}</td>
+                                                <td class="px-4 py-2 text-sm text-right">
+                                                    <a href="{{ route('ecommerce.reservations.edit', $reservation) }}" class="text-indigo-600 hover:text-indigo-900 mr-2">Edit</a>
+                                                    <form action="{{ route('ecommerce.reservations.destroy', $reservation) }}" method="POST" class="inline">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit" class="text-red-600 hover:text-red-900" onclick="return confirm('Hapus reservasi ini?')">Hapus</button>
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        @else
+                            <p class="mb-6 text-sm text-gray-500">Belum ada reservasi yang Anda buat.</p>
+                        @endif
+
+                        <div id="calendar"></div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
+    @push('scripts')
+    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var calendarEl = document.getElementById('calendar');
+            var calendar = new FullCalendar.Calendar(calendarEl, {
+                initialView: 'dayGridMonth',
+                events: '{{ route('ecommerce.reservations.events') }}',
+                eventClick: function(info) {
+                    window.location.href = '{{ url('ecommerce/reservations') }}/' + info.event.id + '/edit';
+                }
+            });
+            calendar.render();
+        });
+    </script>
+    @endpush
 </x-app-layout>

--- a/resources/views/ecommerce/reservations/create.blade.php
+++ b/resources/views/ecommerce/reservations/create.blade.php
@@ -1,0 +1,30 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Tambah Reservasi</h2>
+    </x-slot>
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    @if($errors->any())
+                        <div class="mb-4 text-red-600">
+                            <ul class="list-disc list-inside">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                    <form method="POST" action="{{ route('ecommerce.reservations.store') }}" class="space-y-6">
+                        @csrf
+                        @include('ecommerce.reservations.form')
+                        <div class="flex justify-end">
+                            <a href="{{ route('ecommerce.dashboard') }}" class="px-4 py-2 mr-2 bg-gray-300 rounded">Batal</a>
+                            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Simpan</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/ecommerce/reservations/edit.blade.php
+++ b/resources/views/ecommerce/reservations/edit.blade.php
@@ -1,0 +1,31 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Edit Reservasi</h2>
+    </x-slot>
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    @if($errors->any())
+                        <div class="mb-4 text-red-600">
+                            <ul class="list-disc list-inside">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                    <form method="POST" action="{{ route('ecommerce.reservations.update', $reservation) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+                        @include('ecommerce.reservations.form')
+                        <div class="flex justify-end">
+                            <a href="{{ route('ecommerce.dashboard') }}" class="px-4 py-2 mr-2 bg-gray-300 rounded">Batal</a>
+                            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Perbarui</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/ecommerce/reservations/form.blade.php
+++ b/resources/views/ecommerce/reservations/form.blade.php
@@ -1,0 +1,22 @@
+<div class="space-y-4">
+    <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Nama Tamu</label>
+        <input type="text" name="guest_name" value="{{ old('guest_name', isset($reservation) ? $reservation->guest_name : '') }}" class="mt-1 block w-full border-gray-300 rounded" required>
+    </div>
+    <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Email Tamu</label>
+        <input type="email" name="guest_email" value="{{ old('guest_email', isset($reservation) ? $reservation->guest_email : '') }}" class="mt-1 block w-full border-gray-300 rounded">
+    </div>
+    <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Tanggal Check-in</label>
+        <input type="date" name="checkin_date" value="{{ old('checkin_date', isset($reservation) ? $reservation->checkin_date : '') }}" class="mt-1 block w-full border-gray-300 rounded" required>
+    </div>
+    <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Tanggal Check-out</label>
+        <input type="date" name="checkout_date" value="{{ old('checkout_date', isset($reservation) ? $reservation->checkout_date : '') }}" class="mt-1 block w-full border-gray-300 rounded" required>
+    </div>
+    <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Jumlah Kamar</label>
+        <input type="number" min="1" name="number_of_rooms" value="{{ old('number_of_rooms', isset($reservation) ? $reservation->number_of_rooms : 1) }}" class="mt-1 block w-full border-gray-300 rounded" required>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\SettingController;
 use App\Http\Controllers\Admin\PricingRuleController;
 use App\Http\Controllers\Ecommerce\DashboardController;
+use App\Http\Controllers\Ecommerce\ReservationController as EcommerceReservationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -157,6 +158,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('ecommerce.')
         ->group(function () {
             Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
+            Route::get('reservations/events', [EcommerceReservationController::class, 'events'])->name('reservations.events');
+            Route::resource('reservations', EcommerceReservationController::class)->except(['index', 'show']);
         });
 });
 


### PR DESCRIPTION
## Summary
- allow ecommerce users to create, edit, and delete their own reservations
- keep daily occupancy in sync with reservation changes
- display a reservation list and editable calendar on the ecommerce dashboard

## Testing
- `php artisan test` *(fails: table "properties" already exists)*

------
https://chatgpt.com/codex/tasks/task_b_6890690f629c83298774c3773ee7926a